### PR TITLE
Add editing sheet

### DIFF
--- a/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/Wheel.kt
+++ b/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/Wheel.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -56,11 +56,11 @@ import com.jeanbarrossilva.self.platform.ui.theme.SelfTheme
 @Composable
 internal fun Wheel(
     viewModel: WheelViewModel,
-    onToDoCompositionRequest: () -> Unit,
+    onEditRequest: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val loadable by viewModel.getWheelLoadableFlow().collectAsState()
-    Wheel(loadable, onToDoToggle = viewModel::toggleToDo, onToDoCompositionRequest, modifier)
+    Wheel(loadable, onToDoToggle = viewModel::toggleToDo, onEditRequest, modifier)
 }
 
 @Composable
@@ -68,7 +68,7 @@ internal fun Wheel(
 internal fun Wheel(
     loadable: Loadable<FeatureWheel>,
     onToDoToggle: (area: FeatureArea, toDo: FeatureToDo, isDone: Boolean) -> Unit,
-    onToDoCompositionRequest: () -> Unit,
+    onEditRequest: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val density = LocalDensity.current
@@ -111,9 +111,9 @@ internal fun Wheel(
     Scaffold(
         modifier,
         floatingActionButton = {
-            FloatingActionButton(onClick = onToDoCompositionRequest, isVisible = isFabVisible) {
+            FloatingActionButton(onClick = onEditRequest, isVisible = isFabVisible) {
                 @Suppress("SpellCheckingInspection")
-                Icon(Icons.Rounded.Add, contentDescription = "Adicionar afazer")
+                Icon(Icons.Rounded.Edit, contentDescription = "Adicionar afazer")
             }
         }
     ) {
@@ -188,5 +188,5 @@ private fun LoadedWheelWithToDosPreview() {
 
 @Composable
 private fun Wheel(loadable: Loadable<FeatureWheel>, modifier: Modifier = Modifier) {
-    Wheel(loadable, onToDoToggle = { _, _, _ -> }, onToDoCompositionRequest = { }, modifier)
+    Wheel(loadable, onToDoToggle = { _, _, _ -> }, onEditRequest = { }, modifier)
 }

--- a/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/WheelFragment.kt
+++ b/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/WheelFragment.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.jeanbarrossilva.loadable.flow.unwrap
 import com.jeanbarrossilva.self.feature.wheel.databinding.FragmentWheelBinding
-import com.jeanbarrossilva.self.feature.wheel.scope.todo.ToDoComposerFragment
+import com.jeanbarrossilva.self.feature.wheel.scope.editing.EditingSheetFragment
 import com.jeanbarrossilva.self.platform.ui.core.binding.BindingFragment
 import com.jeanbarrossilva.self.platform.ui.theme.SelfTheme
 import com.jeanbarrossilva.self.wheel.core.infra.WheelEditor
@@ -34,7 +34,7 @@ internal class WheelFragment : BindingFragment<FragmentWheelBinding>() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding?.root?.setContent {
             SelfTheme {
-                Wheel(viewModel, onToDoCompositionRequest = ::navigateToToDoComposer)
+                Wheel(viewModel, onEditRequest = ::navigateToEditingSheet)
             }
         }
     }
@@ -44,10 +44,10 @@ internal class WheelFragment : BindingFragment<FragmentWheelBinding>() {
         boundary.navigateToQuestionnaire(navController)
     }
 
-    private fun navigateToToDoComposer() {
+    private fun navigateToEditingSheet() {
         lifecycleScope.launch {
             val wheel = viewModel.getWheelLoadableFlow().unwrap().first()
-            activity?.let { ToDoComposerFragment.show(it, wheel.areas) }
+            activity?.let { EditingSheetFragment.show(it, wheel.areas) }
         }
     }
 }

--- a/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/scope/editing/EditingSheet.kt
+++ b/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/scope/editing/EditingSheet.kt
@@ -1,0 +1,67 @@
+package com.jeanbarrossilva.self.feature.wheel.scope.editing
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.aurelius.utils.copy
+import com.jeanbarrossilva.self.feature.wheel.scope.editing.ui.actionable.Button
+import com.jeanbarrossilva.self.platform.ui.core.sheet.Sheet
+import com.jeanbarrossilva.self.platform.ui.core.sheet.SheetDefaults
+import com.jeanbarrossilva.self.platform.ui.theme.SelfTheme
+
+@Composable
+internal fun EditingSheet(
+    onToDoCompositionRequest: () -> Unit,
+    onEditRequest: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val lazyListState = rememberLazyListState()
+
+    Sheet(
+        title = {
+            @Suppress("SpellCheckingInspection")
+            Text("Editar")
+        },
+        modifier,
+        isContentPadded = false
+    ) {
+        LazyRow(
+            Modifier.fillMaxWidth(),
+            lazyListState,
+            SheetDefaults.padding.copy(top = 0.dp),
+            horizontalArrangement = Arrangement
+                .spacedBy(SelfTheme.sizes.spacing.medium, Alignment.CenterHorizontally)
+        ) {
+            item {
+                Button(onClick = onToDoCompositionRequest) {
+                    @Suppress("SpellCheckingInspection")
+                    Text("Adicionar afazer")
+                }
+            }
+
+            item {
+                Button(onClick = onEditRequest) {
+                    @Suppress("SpellCheckingInspection")
+                    Text("Modificar áreas")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+private fun EditingSheetPreview() {
+    SelfTheme {
+        EditingSheet(onToDoCompositionRequest = { }, onEditRequest = { })
+    }
+}

--- a/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/scope/editing/EditingSheetFragment.kt
+++ b/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/scope/editing/EditingSheetFragment.kt
@@ -1,0 +1,38 @@
+package com.jeanbarrossilva.self.feature.wheel.scope.editing
+
+import androidx.compose.runtime.Composable
+import androidx.fragment.app.FragmentActivity
+import com.jeanbarrossilva.self.feature.wheel.domain.FeatureArea
+import com.jeanbarrossilva.self.feature.wheel.scope.todo.ToDoComposerFragment
+import com.jeanbarrossilva.self.platform.ui.core.sheet.SheetFragment
+
+internal class EditingSheetFragment() : SheetFragment() {
+    private var areas = emptyList<FeatureArea>()
+
+    constructor(areas: List<FeatureArea>) : this() {
+        this.areas = areas
+    }
+
+    @Composable
+    override fun Content() {
+        EditingSheet(
+            onToDoCompositionRequest = ::navigateToToDoComposer,
+            onEditRequest = ::navigateToWheelEditor
+        )
+    }
+
+    private fun navigateToToDoComposer() {
+        activity?.let {
+            ToDoComposerFragment.show(it, areas)
+        }
+    }
+
+    private fun navigateToWheelEditor() {
+    }
+
+    companion object {
+        fun show(activity: FragmentActivity, areas: List<FeatureArea>) {
+            EditingSheetFragment(areas).show(activity.supportFragmentManager, "editing_sheet")
+        }
+    }
+}

--- a/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/scope/editing/ui/actionable/Button.kt
+++ b/feature-wheel/src/main/java/com/jeanbarrossilva/self/feature/wheel/scope/editing/ui/actionable/Button.kt
@@ -1,0 +1,41 @@
+package com.jeanbarrossilva.self.feature.wheel.scope.editing.ui.actionable
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.jeanbarrossilva.aurelius.ui.theme.AureliusTheme
+import com.jeanbarrossilva.self.feature.wheel.scope.editing.ui.actionable.Button as _Button
+import com.jeanbarrossilva.self.platform.ui.theme.SelfTheme
+
+@Composable
+internal fun Button(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    Button(
+        onClick,
+        modifier,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = AureliusTheme.colors.container.tertiary,
+            contentColor = AureliusTheme.colors.content.tertiary
+        ),
+        content = content
+    )
+}
+
+@Composable
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+private fun ButtonPreview() {
+    SelfTheme {
+        _Button(onClick = { }) {
+            Text("Rótulo")
+        }
+    }
+}

--- a/platform-ui/src/main/java/com/jeanbarrossilva/self/platform/ui/core/sheet/Sheet.kt
+++ b/platform-ui/src/main/java/com/jeanbarrossilva/self/platform/ui/core/sheet/Sheet.kt
@@ -18,27 +18,42 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.aurelius.utils.end
+import com.jeanbarrossilva.aurelius.utils.start
 import com.jeanbarrossilva.self.platform.ui.theme.SelfTheme
-import com.jeanbarrossilva.self.platform.ui.utils.elevated
 import com.jeanbarrossilva.self.platform.ui.utils.top
 
 @Composable
 fun Sheet(
     title: @Composable () -> Unit,
     modifier: Modifier = Modifier,
+    isContentPadded: Boolean = true,
     content: @Composable () -> Unit
 ) {
     Sheet(modifier) {
         LazyColumn(
             Modifier.fillMaxWidth(),
-            contentPadding = it,
+            contentPadding = if (isContentPadded) SheetDefaults.padding else PaddingValues(0.dp),
             verticalArrangement = Arrangement.spacedBy(SelfTheme.sizes.spacing.large)
         ) {
             item {
                 ProvideTextStyle(
-                    SelfTheme.text.title.large.copy(SelfTheme.colors.text.highlighted),
-                    title
-                )
+                    SelfTheme.text.title.large.copy(SelfTheme.colors.text.highlighted)
+                ) {
+                    if (!isContentPadded) {
+                        Box(
+                            Modifier.padding(
+                                start = SheetDefaults.padding.start,
+                                top = SheetDefaults.padding.calculateTopPadding(),
+                                end = SheetDefaults.padding.end
+                            )
+                        ) {
+                            title()
+                        }
+                    } else {
+                        title()
+                    }
+                }
             }
 
             item {
@@ -51,7 +66,7 @@ fun Sheet(
 @Composable
 fun Sheet(
     modifier: Modifier = Modifier,
-    content: @Composable ColumnScope.(padding: PaddingValues) -> Unit
+    content: @Composable ColumnScope.() -> Unit
 ) {
     Column {
         Box(
@@ -66,7 +81,7 @@ fun Sheet(
         Card(
             modifier.fillMaxWidth(),
             SelfTheme.shapes.large.top,
-            CardDefaults.cardColors(containerColor = SelfTheme.colors.elevated),
+            CardDefaults.cardColors(SheetDefaults.containerColor),
             CardDefaults.cardElevation(
                 defaultElevation = 0.dp,
                 pressedElevation = 0.dp,
@@ -76,7 +91,7 @@ fun Sheet(
                 disabledElevation = 0.dp
             )
         ) {
-            content(SheetDefaults.padding)
+            content()
         }
     }
 }
@@ -88,7 +103,7 @@ private fun UntitledSheetPreview() {
     SelfTheme {
         Sheet {
             @Suppress("SpellCheckingInspection")
-            Text("Conteúdo", Modifier.padding(it))
+            Text("Conteúdo", Modifier.padding(SheetDefaults.padding))
         }
     }
 }

--- a/platform-ui/src/main/java/com/jeanbarrossilva/self/platform/ui/core/sheet/SheetDefaults.kt
+++ b/platform-ui/src/main/java/com/jeanbarrossilva/self/platform/ui/core/sheet/SheetDefaults.kt
@@ -3,8 +3,11 @@ package com.jeanbarrossilva.self.platform.ui.core.sheet
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import com.jeanbarrossilva.self.platform.ui.theme.SelfTheme
+import com.jeanbarrossilva.self.platform.ui.utils.elevated
 
 object SheetDefaults {
     val padding
         @Composable get() = PaddingValues(SelfTheme.sizes.spacing.huge)
+    val containerColor
+        @Composable get() = SelfTheme.colors.elevated
 }


### PR DESCRIPTION
Instead of directly taking the user to the to-do composer when clicking the FAB, navigates them to the editing sheet, from where they can choose to go either to the to-do composer or the wheel editor (no-op for now).

<img width="512" src="https://user-images.githubusercontent.com/38408390/233056724-4d4ab356-2e18-4b3b-a5d7-497a1b135741.png">
